### PR TITLE
Update client.rb require statement to fix infoboxer error: 'gems/mediawiktory-0.1.1/lib/mediawiktory/wikipedia/client.rb:3:in `require': cannot load such file -- addressable (LoadError)'

### DIFF
--- a/lib/mediawiktory/wikipedia/client.rb
+++ b/lib/mediawiktory/wikipedia/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'addressable'
+require 'addressable/uri'
 require 'faraday'
 require 'faraday_middleware'
 

--- a/lib/mediawiktory/wikipedia/client.rb
+++ b/lib/mediawiktory/wikipedia/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'addressable/uri'
+require 'addressable/template'
 require 'faraday'
 require 'faraday_middleware'
 


### PR DESCRIPTION
I might be totally off here, but I found that infoboxer wouldn't run because it couldn't import mediawiktory correctly, and mediawiktory wasn't running correctly because of an error with the require statement here.

I had a freshly installed infoboxer gem via my gemfile followed by bundle install, but adding `require 'infoboxer'` to my simple ruby script threw an error
```
/Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory/wikipedia/client.rb:3:in `require': cannot load such file -- addressable (LoadError)
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory/wikipedia/client.rb:3:in `<top (required)>'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory/wikipedia/api.rb:3:in `require_relative'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory/wikipedia/api.rb:3:in `<top (required)>'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory.rb:15:in `require_relative'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory.rb:15:in `<module:MediaWiktory>'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/mediawiktory-0.1.1/lib/mediawiktory.rb:13:in `<top (required)>'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/infoboxer-0.3.0/lib/infoboxer/media_wiki.rb:3:in `require'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/infoboxer-0.3.0/lib/infoboxer/media_wiki.rb:3:in `<top (required)>'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/infoboxer-0.3.0/lib/infoboxer.rb:244:in `require_relative'
	from /Users/chrisa/.rvm/gems/ruby-2.4.0/gems/infoboxer-0.3.0/lib/infoboxer.rb:244:in `<top (required)>'
	from fetch_account_info_from_wiki.rb:5:in `require'
	from fetch_account_info_from_wiki.rb:5:in `<main>
```

Was able to fix the error by looking at how addressable suggests to add its require statement and updating mediawiktory locally to reflect their style: https://github.com/sporkmonger/addressable#reference

This might not be the correct solution but figured I should throw this up in case there is in fact a bug here?